### PR TITLE
Improvement/docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,10 @@ downloads/
 eggs/
 lib/
 lib64/
+lib64
 parts/
+include/
+.idea/
 sdist/
 var/
 *.egg-info/
@@ -37,6 +40,7 @@ htmlcov/
 .tox/
 .coverage
 .cache
+pip-selfcheck.json
 nosetests.xml
 coverage.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
 install:
   - bin/buildout -N
 script:
-  - bin/nosetests openprocurement docs.py
+  - bin/nosetests src docs.py
 after_success:
   - bin/coveralls
+  - ./push_http_files.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ before_install:
 install:
   - bin/buildout -N
 script:
-  - bin/nosetests
+  - bin/nosetests openprocurement docs.py
 after_success:
   - bin/coveralls

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -12,5 +12,6 @@ recipe = zc.recipe.egg:scripts
 dependent-scripts = true
 eggs =
     openprocurement.api [test]
+    openprocurement.tender.belowthreshold
     nose
 #    pylint

--- a/docs.py
+++ b/docs.py
@@ -6,9 +6,9 @@ from datetime import timedelta, datetime
 from uuid import uuid4
 
 import openprocurement.api.tests.base as base_test
-from openprocurement.api.tests.base import test_tender_data, test_bids, PrefixedRequestClass
+from openprocurement.tender.belowthreshold.tests.base import test_tender_data, test_bids, BaseTenderWebTest
+from openprocurement.api.tests.base import PrefixedRequestClass
 from openprocurement.api.models import get_now
-from openprocurement.api.tests.tender import BaseTenderWebTest
 from webtest import TestApp
 
 now = datetime.now()

--- a/push_http_files.sh
+++ b/push_http_files.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+if [ ${SANDBOX_MODE} ]
+then
+    exit
+fi
+
+DOCS_ACC='ProzorroUKR'
+DOCS_REPO='prozorro-docs'
+CUR_DIR="${PWD##*/}"
+SOURCES="../$CUR_DIR/docs/source"
+TARGET_DIR='docs/source/http'
+
+# getting current branch name with changes (which's different on Travis for pull requests and direct merges)
+if [ -z ${TRAVIS_PULL_REQUEST_BRANCH} ]  # if it's empty (not a pull request)
+then
+    BRANCH=${TRAVIS_BRANCH}  # the name of the triggered (by merge or tag) branch
+else
+    BRANCH=${TRAVIS_PULL_REQUEST_BRANCH}  #  the name of the branch from which the PR originated
+fi
+
+cd ..
+
+# prepare rep and branch
+git clone "https://github.com/$DOCS_ACC/$DOCS_REPO.git"
+cd "$DOCS_REPO"
+git checkout "$BRANCH" || git checkout -b "$BRANCH"
+
+# move files
+rm -rf "$TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+cp -R "$SOURCES/tutorial" "$TARGET_DIR"
+cp -R "$SOURCES/qualification" "$TARGET_DIR"
+cp -R "$SOURCES/complaints" "$TARGET_DIR"
+
+# commit and push files
+git add "$TARGET_DIR"
+git commit -a -m "Auto http-files update from $TRAVIS_REPO_SLUG branch=$BRANCH travis-build=$TRAVIS_BUILD_NUMBER"
+git push "https://$GIT_USER:$GIT_TOKEN@github.com/$DOCS_ACC/$DOCS_REPO.git" "$BRANCH"

--- a/src/openprocurement/api/tests/auth.ini
+++ b/src/openprocurement/api/tests/auth.ini
@@ -1,2 +1,30 @@
+[auction]
+auction = auction
+
+[chronograph]
+chronograph = chronograph
+
+[Administrator]
+administrator = administrator
+
 [tests]
 chrisr = chrisr
+
+[brokers]
+broker = broker
+broker05 = broker05
+broker1 = broker1,1
+broker2 = broker2,2
+broker3 = broker3,3
+broker4 = broker4,4
+broker1t = broker1t,1t
+broker2t = broker2t,2t
+
+[reviewers]
+reviewer = reviewer
+
+[admins]
+test = token
+
+[bots]
+bot = bot

--- a/src/openprocurement/api/tests/tests.ini
+++ b/src/openprocurement/api/tests/tests.ini
@@ -12,7 +12,7 @@ pyramid.debug_notfound = false
 pyramid.debug_routematch = false
 pyramid.debug_templates = true
 pyramid.default_locale_name = en
-plugins = api
+plugins = api,tender_core,belowThreshold
 
 [server:main]
 use = egg:chaussette

--- a/versions.cfg
+++ b/versions.cfg
@@ -10,6 +10,7 @@ docutils = 0.12
 jsonpointer = 1.9
 nose = 1.3.7
 py = 1.4.26
+pylint = 1.9.3
 pyramid = 1.6.1
 python-coveralls = 2.5.0
 repoze.lru = 0.6


### PR DESCRIPTION
- Пофиксил запуск  docs.py
- Добавил  пуш http-файлов в репу с документацией
Пример того что апдейтит пуш https://github.com/ProzorroUKR/prozorro-docs/pull/1/files
Сейчас он запушил в ветку improvement/docs тк билд был для этой ветки. Как зальем на в мастер, обновится мастер и обновится документация с этими файлами.

Добавлю аналогичные апдейты в остальные репы с доками.
https://github.com/ProzorroUKR/openprocurement.contracting.api/pull/2
https://github.com/ProzorroUKR/openprocurement.tender.openuadefense/pull/2
https://github.com/ProzorroUKR/openprocurement.tender.limited/pull/2
https://github.com/ProzorroUKR/openprocurement.tender.openua/pull/2
https://github.com/ProzorroUKR/openprocurement.tender.openeu/pull/4