### PR TITLE
Use reversed lineage context for more weight local roles on models

### DIFF
--- a/src/openprocurement/api/auth.py
+++ b/src/openprocurement/api/auth.py
@@ -95,7 +95,7 @@ def get_local_roles(context):
     from pyramid.location import lineage
 
     roles = {}
-    for location in lineage(context):
+    for location in reversed(list(lineage(context))):
         try:
             local_roles = location.__local_roles__
         except AttributeError:


### PR DESCRIPTION
Ця правка потрібна для того щоб надати більшої ваги локальним ролям контексту.

Проблема полягає в тому, що на даний момент локальні ролі "батька"  перетирають локальні ролі "нащадка" якщо використовуюється один і той же `owner_token`.

Наприклад:
```
Tender
└── Bids
    ├── Bid0
    ├── Bid1
└── Awards
    └── Award0
└── Contracts
    └── Contract0
```

- на моделі **Bid** локальна роль `bid_owner` визначається за принципом
https://github.com/ProzorroUKR/openprocurement.api/blob/26cd718d5a75411df88481709a39a6eb0685bb0e/src/openprocurement/tender/core/models.py#L467-L468

- У об'єкті **Contract** немає жодних токенів. Тому, використали пропозицію (**Bid**) для визначення ролі постачальника (`contract_supplier`) у моделі **Contract**:
 
```python
[("{}_{}".format(bid.owner, bid.owner_token), "contract_supplier")]
```

- на тендері також є локальні ролі які дублють локальні ролі **Bid**
https://github.com/ProzorroUKR/openprocurement.api/blob/26cd718d5a75411df88481709a39a6eb0685bb0e/src/openprocurement/tender/belowthreshold/models.py#L202-L206
Дане дублювання потрібне для того щоб отримати `authenticated_role` як `bid_owner` за межами контексту **Bid**, як приклад: дозволити лише власникам пропозицій подавати скарги на **Award**, для розділення доступів до різного типу документів, а також дана роль записується у поле `author` при додаванні документів та ін .

Коли в нас `context` це `contract`, локальні ролі контракту переписуються локальними ролями тендеру
https://github.com/ProzorroUKR/openprocurement.api/blob/26cd718d5a75411df88481709a39a6eb0685bb0e/src/openprocurement/api/auth.py#L98-L105

В цьому PR пропонується змінити напрямок наслідування ролей - від "батька" до "контексту". На даний момент локальні ролі присутні лише на моделях **(Tender, Bid, Complaint)**. Локальні ролі в **Complaint** ніяк не взаємодіють з **Tender**. Запропонована зміна не впливає на поведінку існуючих ролей по всьому коду так як з **Tender** взаємодіє тільки **Bid**, а ролі визначені в **Bid** сівпадають з **Tender**, тому зміна послідовності формування ніяким чином не впливає на систему в її поточному стані. Детальніше про взаємодію локальних ролей **Tender** та **Bid** описано нижче:

- у моделях **Tender** дублюються локальні ролі **Bid**, для отримання цієї ролі за межами контексту **Bid**, якщо контекстом є об'єкт моделі яка немає локальних ролей, то використовуватимуться ролі які будуть об'єднуватись починаючи з `Root(Tender)` і всіх потомків на шляху до контексту;
https://github.com/ProzorroUKR/openprocurement.api/blob/c4f31ee812e125faa3f51f5edc3d27ea66239166/src/openprocurement/api/auth.py#L98-L105

- на всіх **Bid** додатково визначається локальна роль "власника".

Тому,  в межах контексту **Bid** власник пропозиції завжди отримає "правильну" роль.

Ми пропонуємо додати локальні ролі для **Contract** у #38 і дана зміна є необхідною, оскільки зараз **Tender** "перекриває" все, що визначається "глибше" по ієрархії об'єктів.